### PR TITLE
Add 5 new blog posts on leftist theory and critique

### DIFF
--- a/_posts/2024-06-10-federici-caliban-witch.html
+++ b/_posts/2024-06-10-federici-caliban-witch.html
@@ -1,0 +1,73 @@
+---
+layout: post
+title: "The Burning Times & The Birth of Capitalism: Silvia Federici's 'Caliban and the Witch' Revisited"
+image: federici_caliban_witch_cover.jpg
+author: Left Diary
+permalink: federici-caliban-witch-capitalism
+category: [Feminism, History, Capitalism, Theory]
+published: true
+description: "A critical look at Silvia Federici's 'Caliban and the Witch,' exploring the connection between the persecution of women (witch hunts) and the rise of capitalism."
+---
+
+<h2>Introduction: When the Smoke Clears – Witch Hunts and Capitalism's Dawn</h2>
+
+<p>The image of "The Burning Times" – the centuries of brutal witch hunts that swept across Europe – often conjures notions of religious fanaticism and mass hysteria. But what if this horrific chapter of history was not merely a footnote of superstition, but a calculated and crucial campaign of terror intimately tied to the birth of capitalism? This is the explosive and meticulously argued thesis of Silvia Federici's groundbreaking work, <em>Caliban and the Witch: Women, the Body and Primitive Accumulation</em>.</p>
+
+<p>Federici, a scholar and activist whose work bridges Marxist theory, feminist critique, and radical history, challenges us to see the witch hunts anew. She argues they were a fundamental instrument in the "primitive accumulation" of capital – the violent process by which the emerging capitalist order dispossessed commoners, enclosed lands, and, critically, subjugated the female body to create a new patriarchal order functional to its needs. This post revisits Federici's powerful analysis, exploring how the demonization and persecution of "witches" was instrumental in forging the chains that bind women and exploited peoples to the engine of capital. Prepare to have your understanding of history, and of capitalism itself, profoundly shaken.</p>
+
+<h2>Beyond Superstition: The Witch Hunts as Class War & Gendered Terror</h2>
+
+<p>To understand Federici's argument, we must first move past the simplistic notion that the witch hunts were solely a product of religious superstition or ignorance. While religious ideology certainly provided the language and justification, Federici uncovers a deeper, socio-economic agenda at play. The figure of the "witch," she contends, was a socially constructed enemy, and the hunts were a targeted campaign of terror.</p>
+
+<p>Key aspects of Federici's analysis include:</p>
+<ul>
+    <li><strong>Targeting Resistance and Autonomy:</strong> The women accused of witchcraft were often not random victims. Many were poor, elderly, or lived outside traditional family structures. Crucially, they were frequently community healers, midwives, and keepers of traditional knowledge about contraception and abortion. These women held a certain social power and represented a form of female autonomy that was incompatible with the new capitalist order's need for a disciplined, procreating workforce. Those who resisted the enclosure of common lands or challenged the emerging social hierarchies were particularly vulnerable.</li>
+    <li><strong>Destroying Communal Bonds:</strong> The witch hunts sowed terror and suspicion, atomizing communities. Neighbors were encouraged to denounce neighbors, and family members to testify against each other. This breakdown of solidarity was essential for imposing new forms of social control and individualizing blame for systemic problems like poverty and famine, which were actually consequences of early capitalist policies.</li>
+    <li><strong>The Expropriation of Women's Knowledge and Bodies:</strong> The persecution of female healers and midwives coincided with the rise of a male-dominated medical profession. This wasn't just about replacing one set of practitioners with another; it was about devaluing and criminalizing women's traditional knowledge of the body and reproduction. Federici argues this was a crucial step in asserting patriarchal control over women's reproductive capacities, transforming the female body into a machine for the production of new laborers.</li>
+    <li><strong>Enforcing a New Patriarchal Order:</strong> The witch hunts were, in essence, a war against women. They served to redefine women's role in society, confining them to the domestic sphere, demonizing their sexuality, and instilling a deep-seated fear of female power. This new, more rigid patriarchy was not a holdover from feudalism but a necessary precondition for capitalist development.</li>
+</ul>
+<p>By reframing the witch hunts in this way, Federici reveals them not as an irrational aberration, but as a rational, albeit brutal, strategy in the transition to capitalism – a way to crush resistance and reshape social relations to serve the needs of accumulation.</p>
+
+<h2>Primitive Accumulation: Not Just About Land, But About Bodies</h2>
+
+<p>The concept of "primitive accumulation," most famously articulated by Karl Marx, refers to the historical process of divorcing producers from the means of production – primarily through the enclosure of common lands and the dispossession of peasant populations. This created a propertyless proletariat forced to sell their labor power to survive, a necessary precondition for capitalist industry. However, Federici argues that Marx's account, while foundational, overlooked a crucial dimension: the accumulation of <em>bodies</em>, specifically female bodies.</p>
+
+<p>Federici's vital contribution is to show that the new capitalist order required not only land and resources but also a disciplined and ever-expanding workforce. This necessitated a profound transformation in the social position of women and the valuation of their labor:</p>
+<ul>
+    <li><strong>The War on Women's Reproductive Control:</strong> The witch hunts, with their focus on midwives and women knowledgeable about contraception and abortion, were part of a broader campaign to strip women of control over their own reproductive lives. The state and the church began to aggressively promote pro-natalist policies, criminalizing abortion and contraception, and valorizing motherhood above all else. Women's wombs became public territory, their primary social function reduced to producing future laborers.</li>
+    <li><strong>The Devaluation of Unpaid Reproductive Labor:</strong> Capitalism required the separation of production (for the market, seen as "value-creating") from reproduction (of life, increasingly unpaid and devalued). Women's work in birthing, raising, and caring for workers – the essential labor of social reproduction – was rendered invisible, naturalized as a "female calling" rather than recognized as work. This unpaid labor became a massive subsidy to capital accumulation.</li>
+    <li><strong>The Creation of the Housewife:</strong> The disciplined male worker of the factory needed a disciplined female counterpart in the home. Federici traces how the figure of the full-time housewife, economically dependent on her husband and dedicated to domestic chores and child-rearing, was a specific creation of this period. This new gendered division of labor served to control women, cheapen their labor power when they did enter the wage workforce, and ensure the steady supply of new workers.</li>
+</ul>
+<p>This "accumulation of the female body" was achieved through intense violence, both physical and ideological. The witch hunts were the most extreme manifestation of this terror, but it was also embedded in new laws, religious doctrines, and cultural norms. Federici forces us to see that the foundations of capitalism are soaked not only in the blood of dispossessed peasants and colonized peoples but also in the blood of the "witches" who dared to resist this new world order being built on their subjugated bodies.</p>
+
+<h2>Caliban and the Witch: Resisting Enclosure, Then and Now</h2>
+
+<p>The title of Federici's book, <em>Caliban and the Witch</em>, evokes Shakespeare's <em>The Tempest</em>. Caliban, the indigenous inhabitant of the island, dispossessed and enslaved by the colonizer Prospero, represents the colonized and exploited body, particularly in the context of early capitalist expansion and the plantation system. The Witch, often a figure of female rebellion and resistance to patriarchal and capitalist domination, stands alongside him. For Federici, these figures symbolize the twin targets of primitive accumulation: the bodies of colonized peoples and the bodies of women.</p>
+
+<p>The "enclosures" that Federici describes were not just physical (of land) but also social and bodily. They enclosed women within the domestic sphere, enclosed their knowledge within patriarchal structures, and enclosed their reproductive capacities for the needs of capital. But just as historical enclosures were met with resistance – peasant revolts, women's heresies, slave rebellions – so too are contemporary enclosures.</p>
+
+<p>Federici's analysis provides a powerful historical lens through which to understand present-day struggles:</p>
+<ul>
+    <li><strong>Indigenous land rights movements</strong> fighting against corporate land grabs and resource extraction are modern-day Calibans resisting new forms of enclosure.</li>
+    <li><strong>Feminist movements</strong> fighting for reproductive justice, against gender-based violence, and for the recognition of care work are challenging the ongoing enclosure of women's bodies and labor.</li>
+    <li><strong>Eco-feminist critiques</strong> that highlight the connection between the domination of nature and the domination of women echo the historical link between the witch hunts and the rise of a mechanistic worldview that sees both nature and bodies as resources to be exploited.</li>
+    <li><strong>Movements for global commons</strong> and against the privatization of knowledge and resources continue the struggle against the logic of accumulation that Federici dissects.</li>
+</ul>
+<p><em>Caliban and the Witch</em> is not just a history book; it's a call to recognize the long lineage of resistance to capitalist domination. It reminds us that the struggles against patriarchy, colonialism, and capitalism are deeply intertwined and that the spirit of the "witch" – the rebellious, autonomous woman who refuses to be subjugated – and "Caliban" – the exploited who fights for liberation – endures in countless movements around the world today.</p>
+
+<h2>Conclusion: Reclaiming History, Forging Futures</h2>
+
+<p>Silvia Federici's <em>Caliban and the Witch</em> is a monumental work that fundamentally reshapes our understanding of the origins of capitalism. By meticulously excavating the history of the witch hunts and linking them to the enclosure of commons, the subjugation of women, and the colonization of the Americas, Federici reveals the brutal, gendered violence that was not incidental but <em>integral</em> to the birth of the modern world order.</p>
+
+<p>Her analysis forces us to look beyond the sanitized narratives of economic progress and confront the "hidden abodes" of exploitation – not just in the factory, but in the home, in the community, and in the control of women's bodies and reproductive capacities. It shows how the devaluation of women and their labor was a cornerstone of capital accumulation, a legacy that continues to shape gender relations and economic inequalities today.</p>
+
+<p>Understanding this history is not merely an academic exercise. It is a vital tool for contemporary feminist and anti-capitalist struggles. <em>Caliban and the Witch</em> empowers us by uncovering a hidden history of resistance and by clarifying the deep connections between the oppression of women and the logic of capitalist exploitation. It reminds us that the fight for liberation must confront both the visible and invisible chains that bind us, and that the spirit of the witch, defiant and life-affirming, is needed now more than ever.</p>
+
+<h3>Further Reading & Interlinking</h3>
+<ul>
+    <li><strong>Essential Reading:</strong> <em>Caliban and the Witch: Women, the Body and Primitive Accumulation</em> by Silvia Federici [Affiliate Link: Caliban and the Witch ASIN_PLACEHOLDER]</li>
+    <li>For further exploration of eco-feminist themes and critiques of capitalist patriarchy, consider works like Maria Mies' <em>Patriarchy and Accumulation on a World Scale</em> [Affiliate Link: OTHER_FEMINIST_BOOK_ASIN_PLACEHOLDER] or contemporary eco-feminist authors.</li>
+    <li>Explore more foundational feminist texts: <a href="/_posts/2023-02-15-Beginner-Feminist-Books.html">Beginner Feminist Books</a></li>
+    <li>On the concept of accumulation and ideology within capitalism: <a href="/_posts/2024-06-10-marx-false-consciousness.html">Unmasking the Matrix: Marx, Engels, and 'False Consciousness'</a></li>
+    <li>Delve into related categories: <a href="/category/feminism">Feminism</a>, <a href="/category/capitalism">Capitalism</a>, <a href="/category/history">History</a>, <a href="/category/theory">Theory</a></li>
+</ul>

--- a/_posts/2024-06-10-graeber-bullshit-jobs.html
+++ b/_posts/2024-06-10-graeber-bullshit-jobs.html
@@ -1,0 +1,72 @@
+---
+layout: post
+title: "Beyond the Grind: David Graeber's 'Bullshit Jobs' and the Search for Meaningful Work"
+image: graeber_bullshit_jobs_cover.jpg
+author: Left Diary
+permalink: graeber-bullshit-jobs-summary
+category: capitalism
+published: true
+description: "An exploration of David Graeber's concept of 'bullshit jobs' – meaningless work in modern society – and its psychological and societal implications."
+---
+
+<h2>Introduction: The Silent Epidemic of Pointless Work</h2>
+
+<p>Ever had that nagging feeling that your job, despite the hours you pour into it, doesn't <em>really</em> contribute anything meaningful to the world? That if your role vanished overnight, the gears of society would grind on, utterly indifferent? You're not alone. This quiet desperation is the subject of the late, great anthropologist David Graeber's provocative and essential book, <em>Bullshit Jobs: A Theory</em>.</p>
+
+<p>Graeber, a thinker known for his sharp wit and even sharper critiques of modern capitalism, argues that our societies are riddled with jobs that are, in essence, pointless. These aren't just bad jobs, but roles that the employees themselves secretly believe serve no real purpose. The book isn't just an academic treatise; it's an eye-opening and often infuriating look at how we've come to create and sustain a vast architecture of meaningless employment. This post will delve into Graeber's core arguments, exploring what bullshit jobs are, why they exist, and the profound damage they inflict on our psyches and society.</p>
+
+<h2>What IS a Bullshit Job?</h2>
+
+<p>Graeber's definition is strikingly simple: a bullshit job is "a form of paid employment that is so completely pointless, unnecessary, or pernicious that even the employee cannot justify its existence even though, as part of the conditions of employment, the employee feels obliged to pretend that this is not the case."</p>
+
+<p>It's crucial to distinguish this from what Graeber calls "shit jobs." Shit jobs are often physically demanding, poorly paid, and offer unpleasant working conditions (think cleaners, refuse collectors, care workers). However, these jobs are undeniably necessary. Society needs them to function. A bullshit job, by contrast, could disappear and make no discernible difference – or even make things better.</p>
+
+<p>Graeber identifies five main categories of bullshit jobs:</p>
+<ul>
+    <li><strong>Flunkies:</strong> These jobs exist primarily to make someone else look or feel important. Think of a doorman who does little more than press an elevator button that residents could easily press themselves, or an assistant whose main role is to make their boss feel like they have a retinue. Graeber gives the example of receptionists at companies where the phone rarely rings.</li>
+    <li><strong>Goons:</strong> These roles have an aggressive or deceptive element and exist because others employ them. Corporate lawyers who exist mainly because other corporations have corporate lawyers, or PR specialists whose job is to spin information, or telemarketers trying to sell you things you don't need, fall into this category. Their work often has a negative sum quality.</li>
+    <li><strong>Duct Tapers:</strong> These jobs exist only because of a glitch or fault in the organization that could be fixed but isn't. These employees spend their time patching problems that shouldn't exist in the first place. An example might be an office worker whose sole job is to manually transfer data between two incompatible software systems.</li>
+    <li><strong>Box Tickers:</strong> These roles involve creating the appearance that something useful is being done when it isn't. They allow an organization to claim it is doing something that, in reality, it is not. Think of a committee formed to write a report that no one will read, or an employee filling out endless compliance paperwork that serves no practical purpose.</li>
+    <li><strong>Taskmasters:</strong> These fall into two subcategories. Type one includes those who assign work to others – middle managers who delegate tasks that may themselves be pointless. Type two taskmasters are even more insidious: their role is to create bullshit tasks for others to do, or to supervise people who don't need supervision, essentially inventing work to justify their own position.</li>
+</ul>
+
+<h2>Why Do They Exist? The Paradox of Modern Capitalism</h2>
+
+<p>If capitalism is all about efficiency, why are there so many bullshit jobs? This is a central paradox Graeber tackles. He suggests that the system isn't as rational as it claims to be. Instead of ruthless optimization, we see something else at play.</p>
+
+<p>One compelling idea is "managerial feudalism." In this view, the power and prestige of managers are often tied to the number of subordinates they have, not necessarily the output or efficiency of their department. More underlings mean a bigger empire. This incentivizes the creation of unnecessary roles or layers of bureaucracy.</p>
+
+<p>Graeber also points to the psychological needs of those in power. The feeling of being a "boss" who can command others can be an end in itself. This creates a demand for people to manage, even if their work isn't strictly necessary.</p>
+
+<p>Furthermore, the nature of our economies has shifted. The decline of manufacturing in many Western countries and the explosion of the service, administrative, and corporate sectors have created fertile ground for new kinds of roles. Many of these roles are vaguely defined or exist to support other, equally vague, roles within complex corporate structures. It's a self-perpetuating system where work is created to manage other work, often without a clear connection to producing anything tangible or directly useful.</p>
+
+<h2>The Psychological & Societal Toll</h2>
+
+<p>The impact of bullshit jobs isn't just economic; it's deeply personal and societal. Graeber calls it a "profound psychological violence." Humans have an innate desire to contribute, to make a mark, to feel that their efforts matter. Being forced to pretend to work, to fill hours with tasks you know are meaningless, is a deeply alienating and soul-crushing experience.</p>
+
+<p>Imagine the quiet despair of an intelligent, capable individual spending eight hours a day, five days a week, performing tasks they know are useless. It's a recipe for anxiety, depression, and a profound sense of worthlessness. The book is filled with testimonies from people trapped in such roles, highlighting the misery of having to find ways to look busy while their talents and energies go to waste.</p>
+
+<p>On a societal level, the proliferation of bullshit jobs represents a colossal misallocation of human potential. Think of the innovations never pursued, the community projects never started, the art never created, because bright minds are tied up in corporate make-work. It also fosters a strange societal schizophrenia: we lionize "hard work" as a virtue, yet increasingly, that work has no intrinsic value. This erodes a collective sense of purpose and can lead to widespread cynicism and resentment, especially when those doing genuinely useful (but often poorly compensated) work see others rewarded for effectively doing nothing.</p>
+
+<h2>Beyond Bullshit: What Can Be Done?</h2>
+
+<p>Graeber's book is more of a diagnostic tool than a prescriptive manual, but it inevitably leads to the question: what now? If so much of our work is bullshit, how do we change it?</p>
+
+<p>One idea that Graeber and others have floated is Universal Basic Income (UBI). The logic is that if people's basic survival needs are met, they would be freed from the necessity of taking on pointless jobs simply to make ends meet. This could, in theory, allow people to pursue more meaningful activities, whether that's community work, art, further education, or genuine innovation.</p>
+
+<p>More broadly, Graeber's work calls for a fundamental re-evaluation of what we value as a society. Why do we valorize "work" in the abstract, regardless of its utility or social benefit? What if we prioritized activities that genuinely improve human well-being and planetary health? These are not easy questions, and <em>Bullshit Jobs</em> doesn't pretend to have all the answers. Its power lies in forcing us to confront the absurdity of our current situation and to start asking these uncomfortable but vital questions.</p>
+
+<h2>Conclusion: Reclaiming Our Time and Purpose</h2>
+
+<p>David Graeber's <em>Bullshit Jobs</em> is more than just a catchy title; it's a vital cultural critique that gives a name to a widespread but often unspoken malaise. By dissecting the phenomenon of meaningless work, Graeber challenges us to look beyond the rhetoric of productivity and efficiency and question the very nature of work in the 21st century. His analysis is a call to arms for those who suspect their professional lives are built on a foundation of pointlessness.</p>
+
+<p>The book doesn't just diagnose a problem; it empowers us to speak about it. It validates the frustration of millions and encourages a deeper conversation about what kind of society we want to build. If we spend so much of our lives working, shouldn't that work mean something? Graeber's legacy is in forcing us to ask: if your job disappeared tomorrow, would anyone truly miss it – and if not, what are we all doing this for?</p>
+
+<h3>Further Reading & Interlinking</h3>
+<ul>
+    <li>Read the book: <em>Bullshit Jobs: A Theory</em> by David Graeber [Affiliate Link: Bullshit Jobs by David Graeber ASIN_PLACEHOLDER]</li>
+    <li>Explore another foundational work by Graeber: <em>Debt: The First 5,000 Years</em> [Affiliate Link: Debt by David Graeber ASIN_PLACEHOLDER]</li>
+    <li>Read our previous post on David Graeber: <a href="/_posts/2023-02-05-Graeber.html">David Graeber: Anthropologist, Anarchist, Anti-Capitalist</a></li>
+    <li>Explore more on this topic: <a href="/category/capitalism">Capitalism</a></li>
+    <li>For more introductory texts: <a href="/_posts/2020-06-17-Beginner-leftist-books.html">Beginner Leftist Books</a></li>
+</ul>

--- a/_posts/2024-06-10-marx-false-consciousness.html
+++ b/_posts/2024-06-10-marx-false-consciousness.html
@@ -1,0 +1,86 @@
+---
+layout: post
+title: "Unmasking the Matrix: Marx, Engels, and the Enduring Power of 'False Consciousness'"
+image: marx_false_consciousness_cover.jpg
+author: Left Diary
+permalink: marx-engels-false-consciousness
+category: [Marxism, Theory, Capitalism, Ideology]
+published: true
+description: "A critical exploration of Marx and Engels' concept of 'false consciousness' from *The German Ideology*, its relevance today, and how dominant ideologies can obscure the reality of exploitation."
+---
+
+<h2>Introduction: Are We Living in an Ideological Matrix?</h2>
+
+<p>What if the reality you perceive, the "common sense" that guides your daily life, is not an objective truth but a carefully constructed illusion? Imagine a system, much like the Matrix in the iconic film, that subtly shapes your beliefs, desires, and understanding of the world to serve interests that are not your own. This powerful, often unsettling, idea is at the heart of Karl Marx and Friedrich Engels' concept of "false consciousness."</p>
+
+<p>These two revolutionary thinkers, whose critiques of capitalism still resonate with fierce urgency today, provided us with intellectual tools to dissect the very fabric of societal belief. "False consciousness" is one such critical tool – a concept that helps us understand how dominant ideologies can obscure exploitation, justify inequality, and make the status quo seem natural, inevitable, and even desirable. This post will delve into this challenging idea, exploring its origins, its mechanisms, and its profound relevance in unmasking the deceptions of our contemporary world. Prepare to question the lenses through which you see society.</p>
+
+<h2>What is 'False Consciousness'? Demystifying a Powerful Idea</h2>
+
+<p>At its core, "false consciousness" describes a state where the subordinate classes (primarily the proletariat or working class, in Marx and Engels' analysis) unknowingly accept and adopt the ideology of the dominant class (the bourgeoisie, who own the means of production). This isn't a simple case of being "duped" by lies, but a more profound process where the prevailing ideas in society – about work, success, fairness, freedom, and even human nature – are fundamentally shaped by the interests of those in power.</p>
+
+<p>In their seminal work, *The German Ideology*, Marx and Engels laid the groundwork for this concept. They argued that the class which controls material production also controls mental production. Therefore, the ideas of the ruling class become the ruling ideas of the epoch. These ideas are presented as universal, common sense, or divinely ordained, rather than as expressions of a particular class interest.</p>
+
+<p>Let's break it down:</p>
+<ul>
+    <li><strong>Masking Exploitation:</strong> Capitalist ideology, for instance, might promote the idea that wealth is purely the result of hard work and innovation, downplaying or ignoring the systemic exploitation of labor that generates profit. Workers might then believe their low wages or poor conditions are due to their own failings, not the system itself.</li>
+    <li><strong>Normalizing Inequality:</strong> The belief that society is a meritocracy where everyone has an equal chance to succeed can be a form of false consciousness. It suggests that those at the top deserve their wealth and power, while those at the bottom are there due to lack of effort or talent, thus justifying vast inequalities.</li>
+    <li><strong>Individualism over Collective Action:</strong> An emphasis on individual solutions to systemic problems ("pull yourself up by your bootstraps") can also be a manifestation. This discourages collective organizing and solidarity, which are essential for challenging the power of the dominant class.</li>
+</ul>
+
+<p>Consider the "American Dream": the deeply ingrained belief that anyone, regardless of background, can achieve upward mobility and prosperity through sheer determination. While inspiring for some, this narrative can obscure the significant systemic barriers – class, race, access to education and healthcare – that prevent many from realizing this dream. It places the burden of success or failure entirely on the individual, diverting attention from the structural inequalities inherent in capitalism. Similarly, the idea that "there is no alternative" (TINA) to the current economic system is a powerful form of false consciousness, stifling imagination and resistance.</p>
+
+<h2>The Ruling Ideas are the Ideas of the Ruling Class</h2>
+
+<p>This aphorism from Marx and Engels is a brutal distillation of how ideological dominance works. It's not a conspiracy theory; it's a structural analysis. The bourgeoisie, by virtue of owning the newspapers, the television stations, the publishing houses, the universities, and now, the dominant digital platforms, inevitably project their worldview, their values, their priorities.</p>
+
+<p>Think about it. Who funds the major media outlets? Whose interests are served when news focuses on corporate earnings and stock market fluctuations rather than on wage stagnation or environmental destruction? These aren't accidental biases; they reflect a system where the means of disseminating information are concentrated in the hands of the wealthy.</p>
+
+<p>Educational institutions, too, can play a role. Curricula that lionize "captains of industry" while glossing over labor struggles, or history books that present imperial expansion as a civilizing mission, subtly instill a perspective that aligns with ruling class interests. Even cultural products – films, music, art – can reinforce messages about what constitutes success, normalcy, or rebellion, often channeling discontent into safe, marketable forms.</p>
+
+<p>This isn't to say that every journalist, teacher, or artist is a conscious propagandist. Rather, the system itself, through its funding mechanisms, its reward structures, and its inherent biases, tends to filter and promote ideas that do not fundamentally challenge the existing distribution of power. Dissenting voices are often marginalized, underfunded, or dismissed as "radical" or "unrealistic." The result is a pervasive ideological atmosphere that makes the ruling class's view of the world seem like the only reasonable one.</p>
+
+<h2>Why Does It Matter Today? The Enduring Relevance</h2>
+
+<p>The concept of false consciousness isn't some dusty nineteenth-century relic. It is a vital lens for understanding the ideological battles of our own time. The Matrix, indeed, has been upgraded. </p>
+
+<p><strong>Consumerism as Happiness:</strong> The relentless bombardment of advertising tells us that happiness and self-worth are found in acquiring more things. This isn't just about selling products; it's about promoting an ideology where individual consumption becomes a primary life goal, distracting from deeper sources of fulfillment and collective well-being, and conveniently fueling the engines of capitalist production.</p>
+
+<p><strong>Political Apathy and Cynicism:</strong> The narrative that "all politicians are corrupt" or "voting doesn't change anything" can be a potent form of false consciousness. While often rooted in legitimate grievances, this widespread cynicism can lead to disengagement, effectively leaving the field open for powerful interests to operate unchallenged. It breeds inaction, not empowerment.</p>
+
+<p><strong>The Normalization of Inequality:</strong> Why is it that obscene CEO salaries are often seen as earned, while demands for a living wage for essential workers are dismissed as "unrealistic"? False consciousness helps explain how we come to accept, and even defend, levels of inequality that are objectively harmful and unjust. Narratives around "job creators" versus "takers" play a crucial role here.</p>
+
+<p><strong>Climate Change Denial and Delay:</strong> The fossil fuel industry and its allies have spent decades funding campaigns of misinformation and doubt about climate science. This is a textbook example of a powerful economic interest manufacturing false consciousness to protect its profits, even at the expense of planetary health. They sell us the illusion that meaningful action is too costly, or that technology will magically save us, all while the crisis accelerates.</p>
+
+<p>Understanding false consciousness is like acquiring a decoder ring for the daily barrage of information. It allows us to ask: <em>Cui bono?</em> Who benefits from this idea, this narrative, this policy? It pushes us to look beneath the surface, to identify the class interests at play, and to question the "common sense" that often serves to keep us compliant.</p>
+
+<h2>Beyond False Consciousness: Towards Class Consciousness</h2>
+
+<p>If false consciousness is the ideological fog that obscures reality, then "class consciousness" is the moment the fog begins to lift. For Marx and Engels, this is a critical turning point. It signifies the working class moving from being merely a "class in itself" (a group sharing a common objective position in the economy) to a "class for itself" (a group actively aware of its shared interests, its exploitation, and its collective power to bring about change).</p>
+
+<p>Achieving class consciousness involves recognizing that individual problems – like debt, unemployment, or a sense of powerlessness – are often not personal failings but systemic issues rooted in the class structure of society. It means understanding that the interests of the working class are fundamentally opposed to those of the capitalist class. This awareness is the precondition for collective struggle and the transformation of society.</p>
+
+<p>This isn't about trading one set of dogmas for another. It's about developing a critical understanding of one's own situation and the power structures that shape it. It's the awakening needed to move from passive acceptance to active, informed resistance, paving the way for genuine liberation.</p>
+
+<h2>Conclusion: Choosing to See Beyond the Veil</h2>
+
+<p>The concept of false consciousness, born from the critical minds of Marx and Engels, remains a profoundly challenging and liberating idea. It equips us with the intellectual firepower to dissect the often-invisible ideologies that shape our world, that justify injustice, and that lull us into a state of passive acceptance. Recognizing how these dominant narratives are constructed, and in whose interest they operate, is the first step towards dismantling their power.</p>
+
+<p>To question the "common sense" of our age is not an act of cynicism, but one of courage and intellectual honesty. It is a commitment to seeking truth, even when that truth is uncomfortable or disruptive to our ingrained beliefs. In a world saturated with information, misinformation, and sophisticated propaganda, the ability to critically analyze the ideological underpinnings of society is more crucial than ever.</p>
+
+<p>Ultimately, piercing the veil of false consciousness is about reclaiming our agency. It's about choosing to see the world as it is, not as the powerful wish us to see it. The path from false consciousness to class consciousness is the journey from unwitting pawn to active agent of history. The question remains: are we brave enough to take the red pill and confront the reality of the ideological Matrix we inhabit?</p>
+
+<h3>Further Reading & Interlinking</h3>
+<ul>
+    <li><strong>Key Text:</strong> Selections from <em>The German Ideology</em> by Karl Marx and Friedrich Engels [Affiliate Link: The German Ideology ASIN_PLACEHOLDER]</li>
+    <li><strong>Foundational Work:</strong> <em>The Communist Manifesto</em> by Karl Marx and Friedrich Engels [Affiliate Link: The Communist Manifesto ASIN_PLACEHOLDER]</li>
+    <li>For understanding Marx's economic critique: See our "Beginner Leftist Books" list for guides to <em>Das Kapital</em>. [Link to: _posts/2020-06-17-Beginner-leftist-books.html] (Assuming "Kapital for Beginners" is part of this list rather than a separate post).</li>
+    <li>Explore more foundational texts: <a href="/_posts/2020-06-17-Beginner-leftist-books.html">Beginner Leftist Books</a></li>
+    <li>Delve into related categories: <a href="/category/marxism">Marxism</a>, <a href="/category/capitalism">Capitalism</a>, <a href="/category/theory">Theory</a>, <a href="/category/ideology">Ideology</a></li>
+    <li>For contemporary critiques of capitalist ideology:
+        <ul>
+            <li>Arundhati Roy on <a href="/_posts/2024-06-10-roy-capitalism-ghost-story.html">Capitalism: A Ghost Story</a></li>
+            <li>David Graeber on <a href="/_posts/2024-06-10-graeber-bullshit-jobs.html">Bullshit Jobs</a></li>
+        </ul>
+    </li>
+</ul>

--- a/_posts/2024-06-10-roy-capitalism-ghost-story.html
+++ b/_posts/2024-06-10-roy-capitalism-ghost-story.html
@@ -1,0 +1,63 @@
+---
+layout: post
+title: "Capitalism's Haunted House: Arundhati Roy on the Specters of Dispossession"
+image: roy_capitalism_ghost_story_cover.jpg
+author: Left Diary
+permalink: roy-capitalism-ghost-story-summary
+category: [Capitalism, Neoliberalism, Social Justice]
+published: true
+description: "An exploration of Arundhati Roy's powerful critique of modern capitalism, its impact on the vulnerable, and the 'ghosts' it creates, based on her book *Capitalism: A Ghost Story*."
+---
+
+<h2>Introduction: The Specters of "Progress"</h2>
+
+<p>What if the gleaming towers of progress and the celebratory narratives of economic growth were built on a landscape of invisible suffering? What if the relentless march of modern capitalism left in its wake a trail of dispossessed lives, silenced voices, and plundered environments – ghosts in the machine of accumulation? This is the haunting terrain explored by the incisive writer and activist Arundhati Roy in her searing collection of essays, <em>Capitalism: A Ghost Story</em>.</p>
+
+<p>Roy, renowned for her fierce intellect, unyielding moral clarity, and extraordinary storytelling prowess, turns her gaze towards the dark underbelly of contemporary capitalism. While her lens is often focused on India, a nation caught in the whirlwind of neoliberal transformation, the "ghosts" she uncovers are familiar to anyone witnessing the profound inequalities and injustices playing out on the global stage. This isn't just a book; it's an act of bearing witness, a passionate and critical exposé of a system that too often masks its human cost. Prepare for an eye-opening journey into the hidden realities that sustain the world we think we know.</p>
+
+<h2>The "Ghost Story": What Haunts Modern Capitalism?</h2>
+
+<p>Roy's "ghost story" isn't about supernatural entities in the traditional sense. The ghosts are the millions of people rendered invisible, voiceless, and landless by the predatory logic of late-stage capitalism. She argues that the dazzling spectacle of India's (and the world's) economic boom is a carefully constructed illusion, one that conceals the brutal reality of dispossession and exploitation that fuels it.</p>
+
+<p>Several key themes animate this haunting narrative:</p>
+<ul>
+    <li><strong>The Relentless Engine of Dispossession:</strong> At the heart of Roy's critique is the violent process by which corporations, aided by compliant states, seize land, forests, water, and resources from the poorest and most vulnerable communities – indigenous peoples, farmers, slum dwellers. This isn't an unfortunate byproduct of development; it is, in her analysis, a foundational requirement of a system built on endless accumulation.</li>
+    <li><strong>The Myth of "Progress" and "Development":</strong> Roy relentlessly questions who truly benefits from the mega-projects, the dams, the mines, and the special economic zones that are touted as symbols of national progress. She reveals how "development" often means devastation for the many, while enriching a tiny elite. The narrative of a rising tide lifting all boats is shattered by the reality of deepening inequalities.</li>
+    <li><strong>The Shrinking Spaces for Democracy and Dissent:</strong> As corporate power grows, democratic institutions are often hollowed out, becoming subservient to market dictates. Roy documents how those who resist, who raise their voices against this plunder, are increasingly labelled as "anti-national," "Maoist," or "terrorist." The state, instead of protecting its citizens, often becomes an agent of corporate interests, suppressing dissent through force and intimidation.</li>
+    <li><strong>The Complicity of "Philanthrocapitalism":</strong> Roy extends her critique to the role of large, corporate-funded foundations and NGOs. While seemingly benevolent, she argues that some of these entities can function as "arbiters of policy," channeling dissent into manageable forms and ultimately serving to legitimize and sanitize the very system that creates the problems they claim to address. They risk becoming the "Good Cops" to the "Bad Cop" of outright state repression.</li>
+</ul>
+
+<h2>India as a Microcosm, The World as a Stage</h2>
+
+<p>While <em>Capitalism: A Ghost Story</em> is deeply rooted in the Indian context – its specific political figures, corporations, and sites of struggle – its true power lies in its global resonance. Roy masterfully demonstrates that the dynamics of dispossession, crony capitalism, and the crushing of dissent are not unique to India. They are, rather, characteristic features of the global neoliberal order.</p>
+
+<p>The "ghosts" of India – the Adivasi communities displaced by mining projects, the farmers driven to suicide by debt, the slum-dwellers evicted for beautification drives – have their counterparts across the world. Whether it's land grabs in Africa, resource extraction in Latin America, or austerity measures impoverishing communities in the Global North, the script is hauntingly similar. Roy's analysis provides a framework for understanding these seemingly disparate struggles as interconnected facets of a single, overarching system.</p>
+
+<p>Her passion for justice burns fiercely on every page, transforming a specific critique of Indian capitalism into a universal indictment of a world order that prioritizes profit over people, accumulation over dignity. The faces of the forgotten may change from continent to continent, but the story of their haunting remains disturbingly constant.</p>
+
+<h2>The Power of Storytelling in Resistance</h2>
+
+<p>Arundhati Roy is not just an analyst; she is a storyteller. This is crucial. In a world saturated with data and desensitizing headlines, her power lies in making us <em>feel</em> the human cost of abstract economic policies. She gives voice to the "ghosts," transforming them from statistics into flesh-and-blood individuals whose lives, lands, and dignity are being systematically stripped away.</p>
+
+<p>For Roy, bearing witness through writing is a profound act of resistance. It is a refusal to let these stories be erased or sanitized by official narratives of progress. By meticulously documenting the mechanisms of dispossession and the courage of those who fight back, she challenges the impunity of the powerful. Her essays are not just critiques; they are calls to conscience, attempts to pierce the bubble of indifference that allows such injustices to persist.</p>
+
+<p>In an era where critical voices are often marginalized or attacked, Roy's unwavering commitment to speaking truth to power is both vital and inspiring. She reminds us that language, when wielded with clarity and passion, can be a formidable weapon against oppression. Telling these "ghost stories" becomes a way of reclaiming history, challenging the present, and imagining a more just future.</p>
+
+<h2>Conclusion: Listening to the Echoes in the Haunted House</h2>
+
+<p>Arundhati Roy's <em>Capitalism: A Ghost Story</em> is an urgent, unsettling, and profoundly necessary book. It compels us to look beyond the glittering surfaces of global capitalism and confront the uncomfortable truths hidden in its shadows. The "ghosts" she writes about are not mere figments of imagination; they are the lived realities of countless people whose suffering is the silent subsidy for a system that benefits the few.</p>
+
+<p>Reading Roy is a call to awaken our critical senses. It's an invitation to question the dominant narratives of power, progress, and development that are so often force-fed to us. It challenges us to see the connections between our own lives and the lives of those who are marginalized and dispossessed, no matter how geographically distant they may seem.</p>
+
+<p>The haunted house of capitalism, as Roy paints it, is built on a foundation of forgetting. Her work is an act of remembrance, an insistence that we listen to the echoes of injustice. The ultimate power of her "ghost story" lies in its potential to stir us from our complacency, to recognize the specters of dispossession, and to begin the difficult but essential work of imagining – and fighting for – a world that exorcises these ghosts by choosing justice over profit.</p>
+
+<h3>Further Reading & Interlinking</h3>
+<ul>
+    <li><strong>Essential Reading:</strong> <em>Capitalism: A Ghost Story</em> by Arundhati Roy [Affiliate Link: Capitalism A Ghost Story ASIN_PLACEHOLDER]</li>
+    <li>Delve deeper with Roy's fiction: <em>The God of Small Things</em> [Affiliate Link: The God of Small Things ASIN_PLACEHOLDER]</li>
+    <li>Explore her other powerful essays: Collections like <em>My Seditious Heart</em> or <em>Walking with the Comrades</em>.</li>
+    <li>Read our previous post on Arundhati Roy: <a href="/_posts/2020-03-27-Roy.html">Arundhati Roy: The Doctor and the Saint and Other Essays</a></li>
+    <li>Explore relevant themes: <a href="/category/capitalism">Capitalism</a>, <a href="/category/neoliberalism">Neoliberalism</a>, <a href="/category/social-justice">Social Justice</a></li>
+    <li>For another critical perspective on contemporary issues: <a href="/_posts/2024-06-10-graeber-bullshit-jobs.html">Beyond the Grind: David Graeber's 'Bullshit Jobs'</a></li>
+    <li>For more introductory texts: <a href="/_posts/2020-06-17-Beginner-leftist-books.html">Beginner Leftist Books</a></li>
+</ul>

--- a/_posts/2024-06-10-understanding-imperialism.html
+++ b/_posts/2024-06-10-understanding-imperialism.html
@@ -1,0 +1,95 @@
+---
+layout: post
+title: "Echoes of Empire: Understanding Modern Imperialism Through Classic Leftist Texts"
+image: understanding_imperialism_cover.jpg
+author: Left Diary
+permalink: understanding-modern-imperialism-classic-texts
+category: [Imperialism, Theory, History, Politics, Neocolonialism]
+published: true
+description: "An introduction to classic leftist theories of imperialism (Lenin, Nkrumah, etc.) and their vital role in understanding contemporary global power dynamics and neocolonialism."
+---
+
+<h2>Introduction: The Sun Never Sets on... Exploitation?</h2>
+
+<p>The word "empire" might conjure images of pith helmets and red-coated soldiers, relics of a bygone era. Many believe that the age of formal empires, with their overt colonial administrations, ended with the liberation struggles of the 20th century. But what if empire hasn't disappeared, but merely shapeshifted? What if its mechanisms of control and exploitation have become more subtle, more insidious, yet just as potent?</p>
+
+<p>This post delves into foundational leftist texts that rip the mask off imperialism, both in its classic and contemporary forms. These thinkers provide indispensable tools for understanding how global power dynamics continue to enrich a few at the expense of the many, long after the flags of colonial rulers were lowered. Prepare to see how the echoes of empire resonate powerfully in our 21st-century world, and why these classic critiques are more relevant than ever for anyone seeking to understand – and change – the global order.</p>
+
+<h2>Defining Imperialism: More Than Just Colonies</h2>
+
+<p>At its most basic, imperialism refers to the policy and practice of extending a country's power and influence through colonization, military force, or other means – essentially, one nation exercising political and economic control over another. While empires have existed for millennia, the imperialism that classic leftist thinkers dissected was a specific phenomenon tied to the development of capitalism.</p>
+
+<p>A foundational text for understanding this is V.I. Lenin's <em>Imperialism, the Highest Stage of Capitalism</em> (1917). Writing in the midst of World War I, Lenin wasn't just describing the land grabs of colonial powers; he was analyzing a new stage of capitalist development. His core arguments include:</p>
+<ul>
+    <li><strong>The Concentration of Capital:</strong> Capitalism, Lenin argued, had evolved from free competition to a stage dominated by monopolies and finance capital (the merging of bank and industrial capital). These massive financial oligarchies wielded enormous power.</li>
+    <li><strong>The Export of Capital:</strong> Crucially, mature capitalist economies began to export capital itself, not just goods. Investing in other countries (often colonies or weaker nations) to exploit resources, cheap labor, and new markets became more profitable than investing domestically.</li>
+    <li><strong>The Division of the World:</strong> This drive for markets, resources, and investment opportunities led to the territorial division of the entire world among the major capitalist powers. The "scramble for Africa" was a prime example.</li>
+    <li><strong>Inter-Imperialist Rivalry:</strong> Once the world was divided, competition among these imperialist powers for re-division and control would inevitably lead to conflict and war – a stark explanation for World War I.</li>
+</ul>
+<p>Lenin's work showed that imperialism wasn't just a policy choice but an inherent structural feature of advanced capitalism, a system driven by an insatiable need for expansion and profit. You can find the text here: <em>Imperialism, the Highest Stage of Capitalism</em> [Affiliate Link: Imperialism the Highest Stage of Capitalism ASIN_PLACEHOLDER].</p>
+
+<h2>The Shift to Neo-Colonialism: Same Game, New Rules</h2>
+
+<p>As formal colonial empires began to crumble in the mid-20th century, especially after World War II, one might have assumed that imperialism was breathing its last. However, visionary leaders and thinkers from the newly independent nations quickly recognized that political independence did not automatically translate into genuine sovereignty. Kwame Nkrumah, the first Prime Minister and President of Ghana, was paramount among them.</p>
+
+<p>In his groundbreaking book, <em>Neo-Colonialism, the Last Stage of Imperialism</em> (1965), Nkrumah laid bare the mechanics of this new phase. He argued that neo-colonialism was a more insidious, and often invisible, form of imperial control. While a state might be nominally independent, with its own flag and national anthem, its economic system and political policies were still directed from outside.</p>
+
+<p>Nkrumah identified several key mechanisms of neo-colonial control:</p>
+<ul>
+    <li><strong>Economic Domination:</strong> Former colonial powers, often through multinational corporations, retained control over the resources, industries, and financial institutions of their ex-colonies. Unfair trade terms, where former colonies exported cheap raw materials and imported expensive manufactured goods, perpetuated dependency.</li>
+    <li><strong>Debt Trap Diplomacy:</strong> Loans and "aid" from wealthy nations and international financial institutions (like the IMF and World Bank, often controlled by Western powers) came with strings attached, forcing recipient countries to adopt policies favorable to foreign capital and trapping them in cycles of debt.</li>
+    <li><strong>Puppet Regimes and Political Interference:</strong> Neo-colonial powers would often support and prop up compliant local elites who would serve foreign interests rather than those of their own people. Covert operations and even overt military interventions were used to destabilize or overthrow governments that challenged this order.</li>
+    <li><strong>Cultural Imperialism:</strong> The promotion of Western cultural values, educational systems, and media could erode local cultures and create a mindset of deference to the former colonial masters.</li>
+</ul>
+<p>Nkrumah's analysis was a stark warning: without vigilant awareness and a united front against these new forms of control, independence would remain a hollow shell. His work remains absolutely essential for understanding why so many nations in the Global South continue to struggle for genuine economic and political autonomy. You can find his vital work here: <em>Neo-Colonialism, the Last Stage of Imperialism</em> [Affiliate Link: Neo-Colonialism the Last Stage of Imperialism ASIN_PLACEHOLDER].</p>
+
+<h2>Other Critical Voices (Briefly)</h2>
+
+<p>While Lenin and Nkrumah provide towering analyses, many other thinkers have illuminated crucial facets of imperialism and its devastating consequences. Their works enrich our understanding and deserve attention:</p>
+<ul>
+    <li><strong>Frantz Fanon:</strong> In his searing work, <em>The Wretched of the Earth</em> [Affiliate Link: The Wretched of the Earth ASIN_PLACEHOLDER], Fanon, a psychiatrist from Martinique involved in the Algerian liberation struggle, dissected the profound psychological trauma inflicted by colonialism on both the colonized and the colonizer. He also controversially argued for the necessity of revolutionary violence to achieve genuine decolonization.</li>
+    <li><strong>Walter Rodney:</strong> The Guyanese historian and activist, in his meticulously researched <em>How Europe Underdeveloped Africa</em> [Affiliate Link: How Europe Underdeveloped Africa ASIN_PLACEHOLDER], systematically demonstrated that African "underdevelopment" was not an inherent state but an active process perpetrated by European colonial powers through centuries of exploitation, resource extraction, and the destruction of indigenous industries.</li>
+</ul>
+<p>These are just two examples among many, including thinkers like Rosa Luxemburg, Ho Chi Minh, Che Guevara, Samir Amin, and Edward Said, whose contributions have been vital to anti-imperialist thought and struggle.</p>
+
+<h2>Modern Echoes: Imperialism in the 21st Century</h2>
+
+<p>The theories of Lenin, Nkrumah, Fanon, and Rodney are not mere historical artifacts. They are indispensable tools for understanding the continued operation of imperial power in our supposedly post-colonial world. The language may have changed – "globalization," "development," "humanitarian intervention" – but the underlying dynamics of domination and exploitation often remain chillingly familiar. Consider:</p>
+<ul>
+    <li><strong>Structural Adjustment Programs (SAPs):</strong> Imposed by the International Monetary Fund (IMF) and World Bank on indebted Global South nations, these programs mandate privatization, deregulation, and cuts to social spending. Critics argue these are modern forms of colonial control, forcing countries to open their economies to foreign capital and prioritize debt repayment over the needs of their populations, echoing Nkrumah's warnings about financial control.</li>
+    <li><strong>The Tyranny of Multinational Corporations:</strong> Giant corporations, often based in the Global North, wield enormous power over the economies of developing countries. They exploit cheap labor, extract resources with minimal local benefit, evade taxes, and often operate with impunity regarding environmental damage and labor rights – a clear continuation of the economic exploitation Lenin described.</li>
+    <li><strong>Resource Extraction and "Land Grabs":</strong> The insatiable global demand for minerals, timber, agricultural land, and energy resources continues to drive dispossession in the Global South. Foreign corporations, sometimes in collusion with local elites, acquire vast tracts of land, displacing communities and destroying livelihoods in a process starkly reminiscent of colonial-era enclosures.</li>
+    <li><strong>Military Interventions and the "Responsibility to Protect":</strong> While often framed in terms of humanitarianism or democracy promotion, military interventions by powerful Western nations frequently align with strategic geopolitical and economic interests. These interventions can destabilize regions, install compliant regimes, and secure access to resources, leading many to see them as a modern form of gunboat diplomacy.</li>
+    <li><strong>Cultural Imperialism via Media and Technology:</strong> The global dominance of Western media conglomerates, social media platforms, and entertainment industries shapes perceptions, values, and desires worldwide. This can marginalize local cultures, promote consumerist lifestyles, and subtly reinforce Western geopolitical narratives, fulfilling Nkrumah's concerns about cultural domination.</li>
+    <li><strong>Vaccine Apartheid and Global Health Inequality:</strong> The stark disparities in access to COVID-19 vaccines and other essential medicines highlighted how global health systems can perpetuate inequalities, prioritizing the profits of pharmaceutical corporations and the populations of wealthy nations over the lives of those in poorer countries.</li>
+</ul>
+<p>These examples demonstrate that the core tenets of classic anti-imperialist theory – the drive for profit, the export of capital, the control of resources, the imposition of political and economic dependency, and the ideological justifications for these actions – are tragically alive and well. The empire simply wears new clothes.</p>
+
+<h2>Conclusion: The Critical Imperative of Anti-Imperialist Thought</h2>
+
+<p>The classic leftist texts on imperialism are not just historical documents; they are living theories that provide crucial illumination for our present moment. Understanding the mechanisms of classical colonialism, finance capital, neo-colonialism, and the psychological scars of imperial domination is absolutely essential for any meaningful leftist analysis of global power, inequality, and injustice in the 21st century.</p>
+
+<p>These writers – Lenin, Nkrumah, Fanon, Rodney, and many others – gift us a critical lens. They empower us to look beyond the surface narratives of globalization and development, to identify the power structures that continue to perpetuate dependency and exploitation. They teach us to ask uncomfortable questions about who truly benefits from international trade agreements, development aid, military interventions, and the global flow of capital and culture.</p>
+
+<p>The struggle for genuine liberation, national sovereignty, and a truly equitable global order is far from over. The forms of empire may evolve, but the imperative to resist its depredations remains. By engaging with these classic texts, we equip ourselves with the intellectual armor needed to dismantle the enduring echoes of empire and to fight for a world where all nations and peoples can determine their own destinies, free from external domination.</p>
+
+<h3>Further Reading & Interlinking</h3>
+<ul>
+    <li><strong>Key Texts Mentioned:</strong>
+        <ul>
+            <li>V.I. Lenin, <em>Imperialism, the Highest Stage of Capitalism</em> [Affiliate Link: Imperialism the Highest Stage of Capitalism ASIN_PLACEHOLDER]</li>
+            <li>Kwame Nkrumah, <em>Neo-Colonialism, the Last Stage of Imperialism</em> [Affiliate Link: Neo-Colonialism the Last Stage of Imperialism ASIN_PLACEHOLDER]</li>
+            <li>Frantz Fanon, <em>The Wretched of the Earth</em> [Affiliate Link: The Wretched of the Earth ASIN_PLACEHOLDER]</li>
+            <li>Walter Rodney, <em>How Europe Underdeveloped Africa</em> [Affiliate Link: How Europe Underdeveloped Africa ASIN_PLACEHOLDER]</li>
+        </ul>
+    </li>
+    <li>Explore more foundational texts: <a href="/_posts/2020-06-17-Beginner-leftist-books.html">Beginner Leftist Books</a></li>
+    <li>For contemporary analysis of US foreign policy and imperialism:
+        <ul>
+            <li><a href="/_posts/2020-04-13-Chomsky.html">Noam Chomsky: A Life of Dissent</a></li>
+            <li><a href="/_posts/2020-04-27-10must-read-chomsky.html">10 Must-Read Books by Noam Chomsky</a></li>
+        </ul>
+    </li>
+    <li>On the global impact of capitalism: <a href="/_posts/2024-06-10-roy-capitalism-ghost-story.html">Capitalism's Haunted House: Arundhati Roy on the Specters of Dispossession</a></li>
+    <li>Delve into related categories: <a href="/category/imperialism">Imperialism</a>, <a href="/category/theory">Theory</a>, <a href="/category/history">History</a>, <a href="/category/politics">Politics</a>, <a href="/category/neocolonialism">Neocolonialism</a></li>
+</ul>


### PR DESCRIPTION
This commit introduces five new blog posts covering influential leftist books and themes, as per your request. Each post is designed to be accessible to newcomers while maintaining a critical and passionate tone.

The new posts are:
1.  "Beyond the Grind: David Graeber's 'Bullshit Jobs' and the Search for Meaningful Work" (_posts/2024-06-10-graeber-bullshit-jobs.html)
2.  "Capitalism's Haunted House: Arundhati Roy on the Specters of Dispossession" (_posts/2024-06-10-roy-capitalism-ghost-story.html)
3.  "Unmasking the Matrix: Marx, Engels, and the Enduring Power of 'False Consciousness'" (_posts/2024-06-10-marx-false-consciousness.html)
4.  "The Burning Times & The Birth of Capitalism: Silvia Federici's 'Caliban and the Witch' Revisited" (_posts/2024-06-10-federici-caliban-witch.html)
5.  "Echoes of Empire: Understanding Modern Imperialism Through Classic Leftist Texts" (_posts/2024-06-10-understanding-imperialism.html)

All posts include placeholders for affiliate links and are interlinked with existing and new relevant content to enhance reader navigation and exploration of themes.