### PR TITLE
Feat: Add additional affiliate links to new blog posts

### DIFF
--- a/_posts/2024-06-10-federici-caliban-witch.html
+++ b/_posts/2024-06-10-federici-caliban-witch.html
@@ -65,8 +65,8 @@ description: "A critical look at Silvia Federici's 'Caliban and the Witch,' expl
 
 <h3>Further Reading & Interlinking</h3>
 <ul>
-    <li><strong>Essential Reading:</strong> <em>Caliban and the Witch: Women, the Body and Primitive Accumulation</em> by Silvia Federici [Affiliate Link: Caliban and the Witch ASIN_PLACEHOLDER]</li>
-    <li>For further exploration of eco-feminist themes and critiques of capitalist patriarchy, consider works like Maria Mies' <em>Patriarchy and Accumulation on a World Scale</em> [Affiliate Link: OTHER_FEMINIST_BOOK_ASIN_PLACEHOLDER] or contemporary eco-feminist authors.</li>
+    <li><strong>Essential Reading:</strong> <a href="https://amzn.to/3SQcrQ0"><em>Caliban and the Witch: Women, the Body and Primitive Accumulation</em> by Silvia Federici</a></li>
+    <li>For further exploration of eco-feminist themes and critiques of capitalist patriarchy, consider works like <a href="https://amzn.to/4kFfHtF"><em>Patriarchy and Accumulation on a World Scale</em> by Maria Mies</a> or contemporary eco-feminist authors.</li>
     <li>Explore more foundational feminist texts: <a href="/beginner-feminist-books">Beginner Feminist Books</a></li>
     <li>On the concept of accumulation and ideology within capitalism: <a href="/marx-engels-false-consciousness">Unmasking the Matrix: Marx, Engels, and 'False Consciousness'</a></li>
     <li>Delve into related categories: <a href="/category/feminism">Feminism</a>, <a href="/category/capitalism">Capitalism</a>, <a href="/category/history">History</a>, <a href="/category/theory">Theory</a></li>

--- a/_posts/2024-06-10-graeber-bullshit-jobs.html
+++ b/_posts/2024-06-10-graeber-bullshit-jobs.html
@@ -64,7 +64,7 @@ description: "An exploration of David Graeber's concept of 'bullshit jobs' – m
 
 <h3>Further Reading & Interlinking</h3>
 <ul>
-    <li>Read the book: <em>Bullshit Jobs: A Theory</em> by David Graeber [Affiliate Link: Bullshit Jobs by David Graeber ASIN_PLACEHOLDER]</li>
+    <li>Read the book: <a href="https://amzn.to/45noqfd"><em>Bullshit Jobs: A Theory</em> by David Graeber</a></li>
     <li>Explore another foundational work by Graeber: <em>Debt: The First 5,000 Years</em> [Affiliate Link: Debt by David Graeber ASIN_PLACEHOLDER]</li>
     <li>Read our previous post on David Graeber: <a href="/summary-of-bullshit-jobs-david-graeber">David Graeber: Anthropologist, Anarchist, Anti-Capitalist</a></li>
     <li>Explore more on this topic: <a href="/category/capitalism">Capitalism</a></li>

--- a/_posts/2024-06-10-marx-false-consciousness.html
+++ b/_posts/2024-06-10-marx-false-consciousness.html
@@ -72,8 +72,8 @@ description: "A critical exploration of Marx and Engels' concept of 'false consc
 
 <h3>Further Reading & Interlinking</h3>
 <ul>
-    <li><strong>Key Text:</strong> Selections from <em>The German Ideology</em> by Karl Marx and Friedrich Engels [Affiliate Link: The German Ideology ASIN_PLACEHOLDER]</li>
-    <li><strong>Foundational Work:</strong> <em>The Communist Manifesto</em> by Karl Marx and Friedrich Engels [Affiliate Link: The Communist Manifesto ASIN_PLACEHOLDER]</li>
+    <li><strong>Key Text:</strong> Selections from <a href="https://amzn.to/3ZROZ8X"><em>The German Ideology</em> by Karl Marx and Friedrich Engels</a></li>
+    <li><strong>Foundational Work:</strong> <a href="https://amzn.to/3Hy5Gjo"><em>The Communist Manifesto</em> by Karl Marx and Friedrich Engels</a></li>
     <li>For understanding Marx's economic critique: See our "Beginner Leftist Books" list for guides to <em>Das Kapital</em>. <a href="/beginner-leftist-books">Beginner Leftist Books</a> (Assuming "Kapital for Beginners" is part of this list rather than a separate post).</li>
     <li>Explore more foundational texts: <a href="/beginner-leftist-books">Beginner Leftist Books</a></li>
     <li>Delve into related categories: <a href="/category/marxism">Marxism</a>, <a href="/category/capitalism">Capitalism</a>, <a href="/category/theory">Theory</a>, <a href="/category/ideology">Ideology</a></li>

--- a/_posts/2024-06-10-roy-capitalism-ghost-story.html
+++ b/_posts/2024-06-10-roy-capitalism-ghost-story.html
@@ -53,8 +53,8 @@ description: "An exploration of Arundhati Roy's powerful critique of modern capi
 
 <h3>Further Reading & Interlinking</h3>
 <ul>
-    <li><strong>Essential Reading:</strong> <em>Capitalism: A Ghost Story</em> by Arundhati Roy [Affiliate Link: Capitalism A Ghost Story ASIN_PLACEHOLDER]</li>
-    <li>Delve deeper with Roy's fiction: <em>The God of Small Things</em> [Affiliate Link: The God of Small Things ASIN_PLACEHOLDER]</li>
+    <li><strong>Essential Reading:</strong> <a href="https://amzn.to/3FXmS17"><em>Capitalism: A Ghost Story</em> by Arundhati Roy</a></li>
+    <li>Delve deeper with Roy's fiction: <a href="https://amzn.to/4kzzrPj"><em>The God of Small Things</em></a></li>
     <li>Explore her other powerful essays: Collections like <em>My Seditious Heart</em> or <em>Walking with the Comrades</em>.</li>
     <li>Read our previous post on Arundhati Roy: <a href="/Summary-Capitalism-a-ghost-story">Arundhati Roy: The Doctor and the Saint and Other Essays</a></li>
     <li>Explore relevant themes: <a href="/category/capitalism">Capitalism</a>, <a href="/category/neoliberalism">Neoliberalism</a>, <a href="/category/social-justice">Social Justice</a></li>


### PR DESCRIPTION
This commit incorporates further Amazon affiliate links you provided into the relevant new blog posts:
- _posts/2024-06-10-roy-capitalism-ghost-story.html
- _posts/2024-06-10-marx-false-consciousness.html
- _posts/2024-06-10-graeber-bullshit-jobs.html
- _posts/2024-06-10-federici-caliban-witch.html

The links have been formatted to use the book titles as the anchor text, improving readability and user experience.